### PR TITLE
Add ability to retrieve current scene name

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -89,6 +89,14 @@ pub enum Recording {
     TogglePause,
 }
 
+#[derive(Subcommand, Clone, Debug)]
+pub enum Scene {
+    Current,
+    Switch{
+        scene_name: String,
+    }
+}
+
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 pub struct Cli {
@@ -103,10 +111,8 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Commands {
     Info,
-    Scene {
-        switch_placeholder: String, // NOTE: just for args positioning
-        scene_name: String,
-    },
+    #[clap(subcommand)]
+    Scene (Scene),
     SceneCollection {
         switch_placeholder: String, // NOTE: just for args positioning
         scene_collection_name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,14 +21,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     match &cli.command {
-        Commands::Scene {
-            switch_placeholder,
-            scene_name,
-        } => {
-            // let scene_name = &args[3];
-            let res = client.scenes().set_current_program_scene(scene_name).await;
-            println!("Set current scene: {} {}", switch_placeholder, scene_name);
-            println!("Result: {:?}", res);
+        Commands::Scene(action) => {
+            use Scene::*;
+
+            match action {
+                Current => {
+                    let scene_name = client.scenes().current_program_scene().await.and_then(|r| Ok(r)).unwrap_or("Unknown".to_string());
+                    println!("{}", scene_name);
+                },
+                Switch{scene_name} => {
+                    let res = client.scenes().set_current_program_scene(scene_name).await;
+                    println!("Set current scene: switch {}", scene_name);
+                    println!("Result: {:?}", res);
+                },
+            }
         }
 
         Commands::SceneCollection {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             match action {
                 Current => {
-                    let scene_name = client.scenes().current_program_scene().await.and_then(|r| Ok(r)).unwrap_or("Unknown".to_string());
+                    let scene_name = client.scenes().current_program_scene().await.and_then(|r| Ok(r))?;
                     println!("{}", scene_name);
                 },
                 Switch{scene_name} => {


### PR DESCRIPTION
Allow for retrieving the current scene name requested in [this issue](https://github.com/grigio/obs-cmd/issues/62).  Chose to put the "current" command under the "scene" namespace to keep scene related items grouped together.