### PR TITLE
Fix SceneCollection and added TriggerHotkey

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -158,4 +158,8 @@ pub enum Commands {
         source: String,
     }
 
+    TriggerHotkey {
+        name: String,
+    }
+
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -149,7 +149,8 @@ pub enum Commands {
         compression_quality: Option<i32>,
     },
 
-    ToggleMute {
+    Audio {
+        command: String,
         device: String,
     },
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -97,6 +97,14 @@ pub enum Scene {
     }
 }
 
+#[derive(Subcommand, Clone, Debug)]
+pub enum SceneCollection {
+    Current,
+    Switch{
+        scene_collection_name: String,
+    }
+}
+
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 pub struct Cli {
@@ -113,10 +121,9 @@ pub enum Commands {
     Info,
     #[clap(subcommand)]
     Scene (Scene),
-    SceneCollection {
-        switch_placeholder: String, // NOTE: just for args positioning
-        scene_collection_name: String,
-    },
+
+    #[clap(subcommand)]
+    SceneCollection (SceneCollection),
 
     #[clap(subcommand)]
     Replay(Replay),
@@ -156,7 +163,7 @@ pub enum Commands {
         command: String,
         scene: String,
         source: String,
-    }
+    },
 
     TriggerHotkey {
         name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,10 +227,27 @@ let client = match std::env::var("OBS_WEBSOCKET_URL") {
             }
         }
 
-        Commands::ToggleMute { device } => {
-            println!("Toggling mute on device: {:?}  ", device);
+        Commands::Audio {
+            command,
+            device
+        } => {
+            println!("Audio: {:?} {:?}", command, device);
 
-            let res = client.inputs().toggle_mute(device).await;
+            let muted: bool = match command.as_str() {
+                "mute" => true,
+                "unmute" => false,
+                "toggle" => !client.inputs().muted(device).await?,
+                "status" => {
+                    let status = client.inputs().muted(device).await?;
+                    println!("Muted: {:?}", status);
+                    return Ok(());
+                }
+                _ => {
+                    println!("Invalid audio command: {:?}", command);
+                    return Ok(());
+                }
+            };
+            let res = client.inputs().set_muted(device, muted).await;
             println!("Result: {:?}", res);
         }
 


### PR DESCRIPTION
Fixed the parlance on how the scene collection command is handled to more closely reflect the source command.

Added TriggerHotkey functionality to allow triggering of hotkeys set up in scripts or to get function not possible through the obws protocol (e.g. screenshot output).