### PR TITLE
Bump version to 0.18.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obs-cmd"
-version = "0.18.1"
+version = "0.18.5"
 edition = "2021"
 description = "A minimal command to control obs via obs-websocket"
 authors = ["Luigi Maselli <luigi@grigio.org>"]


### PR DESCRIPTION
The build number in Cargo.toml still says 0.18.1 and should probably be updated to match the actual latest release.

(Also it creates extra work for me to patch the version in my ebuilds for gentoo)